### PR TITLE
Removes import of missing graphhopper js client.

### DIFF
--- a/deckgl/app.js
+++ b/deckgl/app.js
@@ -5,7 +5,6 @@ import autobind from 'react-autobind';
 
 import {StaticMap} from 'react-map-gl';
 import DeckGL, {MapView, MapController, LineLayer, ScatterplotLayer, GeoJsonLayer} from 'deck.gl';
-import {GraphHopper} from 'graphhopper-js-api-client';
 import {setParameters} from 'luma.gl';
 
 // Set your maptiler token here: https://www.maptiler.com/cloud/


### PR DESCRIPTION
Does not compile with the import and it is not used either. To keep it we would have to add dependency to package.json.